### PR TITLE
Fix --exit-on-error returning success on failure

### DIFF
--- a/run-parts
+++ b/run-parts
@@ -273,4 +273,4 @@ echo "$filelist" | while read bname ; do
     fi
 done
 
-exit 0
+exit ${?}


### PR DESCRIPTION
As mentioned in #4, --exit-on-error is not returning an error if a script exits with an error